### PR TITLE
Implement chapman_oai_dc mapper

### DIFF
--- a/metadata_mapper/mappers/mapper.py
+++ b/metadata_mapper/mappers/mapper.py
@@ -99,15 +99,15 @@ class Record(ABC, object):
 
     def UCLDC_map(self) -> dict:
         """
-        Defines mappings from source metdata to UCDLC that are specific
+        Defines mappings from source metadata to UCDLC that are specific
         to this implementation.
 
         All dicts returned by this method up the ancestor chain
         are merged together to produce a final result.
         """
         return {
-            "isShownAt": self.map_is_shown_at(),
-            "isShownBy": self.map_is_shown_by()
+            "is_shown_at": self.map_is_shown_at(),
+            "is_shown_by": self.map_is_shown_by()
         }
 
     @abstractmethod
@@ -120,13 +120,11 @@ class Record(ABC, object):
 
     # Mapper Helpers
     def collate_subfield(self, field: str, subfield: str) -> list:
-        return [f[subfield] for f in self.source_metadata.get(field, [])]
+        return [f[subfield] for f in self.source_metadata.get(self, field, [])]
 
-    def collate_fields(self, fieldlist):
-        ''' collate multiple field values into a single list '''
+    def collate_values(self, values):
         collated = []
-        for field in fieldlist:
-            value = self.source_metadata.get(field)
+        for value in values:
             if value:
                 if isinstance(value, str):
                     collated.append(value)
@@ -134,6 +132,9 @@ class Record(ABC, object):
                     collated.extend(value)
 
         return collated
+
+    def source_metadata_values(self, *args):
+        return [self.source_metadata.get(field) for field in args]
 
     # Enrichments
     # The enrichment chain is a dpla construction that we are porting to Rikolti

--- a/metadata_mapper/mappers/oai/cca_vault_mapper.py
+++ b/metadata_mapper/mappers/oai/cca_vault_mapper.py
@@ -10,16 +10,6 @@ class CcaVaultRecord(OaiRecord):
             "subject": self.map_subject()
         }
 
-    def map_subject(self) -> Union[list[dict[str, str]], None]:
-        # https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/dublin_core_mapper.py#L117-L127
-        value = self.source_metadata.get('subject')
-        if not value:
-            return None
-
-        if isinstance(value, str):
-            value = [value]
-        return [{'name': v} for v in value if v]
-
     def map_is_shown_at(self) -> Union[str, None]:
         return self.transform_identifier()
 
@@ -28,6 +18,7 @@ class CcaVaultRecord(OaiRecord):
             if self.source_metadata.get("type", [])[0].lower() == "image":
                 base_url: str = self.transform_identifier()
                 return f"{base_url.replace('items', 'thumbs')}?gallery=preview"
+
 
     def transform_identifier(self) -> Union[str, None]:
         identifier: list[str] = self.source_metadata.get("identifier")

--- a/metadata_mapper/mappers/oai/chapman_oai_dc_mapper.py
+++ b/metadata_mapper/mappers/oai/chapman_oai_dc_mapper.py
@@ -1,0 +1,49 @@
+from typing import Union
+
+from .oai_mapper import OaiRecord, OaiVernacular
+
+class ChapmanOaiDcRecord(OaiRecord):
+
+    def UCLDC_map(self):
+        return {
+            'description': self.collate_values([
+                self.source_metadata.get('abstract'),
+                self.map_description(),
+                self.source_metadata.get('tableOfContents')
+            ])
+        }
+
+    def map_is_shown_at(self) -> Union[str, None]:
+        return self.identifier_for_image()
+
+    def map_is_shown_by(self) -> Union[str, None]:
+        if not self.is_image_type():
+            return
+
+        url: Union[str, None] = self.identifier_for_image()
+
+        return f"{url.replace('items', 'thumbs')}?gallery=preview" if url else None
+
+    def map_description(self) -> Union[str, None]:
+        if 'description' not in self.source_metadata:
+            return
+
+        return [d for d in self.source_metadata.get('description') if 'thumbnail' not in d]
+
+    def identifier_for_image(self) -> Union[str, None]:
+        if "identifier" not in self.source_metadata:
+            return
+
+        identifiers = [i for i in self.source_metadata.get('identifier') if "context" not in i]
+        return identifiers[0] if identifiers else None
+
+    def is_image_type(self) -> bool:
+        if "type" not in self.source_metadata:
+            return False
+
+        type: list[str] = self.source_metadata.get("type", [])
+
+        return type and type[0].lower() == "image"
+
+class ChapmanOaiDcVernacular(OaiVernacular):
+    record_cls = ChapmanOaiDcRecord

--- a/metadata_mapper/mappers/oai/oai_mapper.py
+++ b/metadata_mapper/mappers/oai/oai_mapper.py
@@ -1,11 +1,11 @@
 import os
 import settings
+from typing import Union
 
 from lxml import etree
 from sickle import models
 
 from ..mapper import Record, Vernacular
-
 
 class OaiRecord(Record):
     """Superclass for OAI metadata."""
@@ -14,53 +14,64 @@ class OaiRecord(Record):
         return {
             'contributor': self.source_metadata.get('contributor'),
             'creator': self.source_metadata.get('creator'),
-            'date': self.collate_fields([
-                "available",
-                "created",
-                "date",
-                "dateAccepted",
-                "dateCopyrighted",
-                "dateSubmitted",
-                "issued",
-                "modified",
-                "valid"
-            ]),
-            'description': self.collate_fields([
-                "abstract",
-                "description",
-                "tableOfContents"
-            ]),
+            'date': self.collate_values(
+                self.source_metadata_values(
+                    'available',
+                    'created',
+                    'date',
+                    'dateAccepted',
+                    'dateCopyrighted',
+                    'dateSubmitted',
+                    'issued',
+                    'modified',
+                    'valid'
+                )
+            ),
+            'description': self.collate_values(
+                self.source_metadata_values('abstract', 'description', 'tableOfContents')
+            ),
             'extent': self.source_metadata.get('extent'),
-            'format': self.collate_fields(["format", "medium"]),
-            'identifier': self.collate_fields(
-                ["bibliographicCitation", "identifier"]),
-            'is_shown_by': self.map_is_shown_by(),
-            'is_shown_at': self.map_is_shown_at(),
+            'format': self.collate_values(self.source_metadata_values('format', 'medium')),
+            'identifier': self.collate_values(self.source_metadata_values('bibliographicCitation', 'identifier')),
+            'is_shown_by': self.source_metadata.get('is_shown_by'),
+            'is_shown_at': self.source_metadata.get('is_shown_at'),
             'provenance': self.source_metadata.get('provenance'),
             'publisher': self.source_metadata.get('publisher'),
-            'relation': self.collate_fields([
-                "conformsTo",
-                "hasFormat",
-                "hasPart",
-                "hasVersion",
-                "isFormatOf",
-                "isPartOf",
-                "isReferencedBy",
-                "isReplacedBy",
-                "isRequiredBy",
-                "isVersionOf",
-                "references",
-                "relation",
-                "replaces",
-                "requires"
-            ]),
-            'rights': self.collate_fields(["accessRights", "rights"]),
-            'spatial': self.collate_fields(["coverage", "spatial"]),
+            'relation': self.collate_values(
+                self.source_metadata_values(
+                    'conformsTo',
+                    'hasFormat',
+                    'hasPart',
+                    'hasVersion',
+                    'isFormatOf',
+                    'isPartOf',
+                    'isReferencedBy',
+                    'isReplacedBy',
+                    'isRequiredBy',
+                    'isVersionOf',
+                    'references',
+                    'relation',
+                    'replaces',
+                    'require'
+                )
+            ),
+            'rights': self.collate_values(self.source_metadata_values('accessRights', 'rights')),
+            'spatial': self.collate_values(self.source_metadata_values('coverage', 'spatial')),
             'subject': self.map_subject(),
             'temporal': self.source_metadata.get('temporal'),
             'title': self.source_metadata.get('title'),
             'type': self.source_metadata.get('type')
         }
+
+    def map_subject(self) -> Union[list[dict[str, str]], None]:
+        # https://github.com/calisphere-legacy-harvester/dpla-ingestion/blob/ucldc/lib/mappers/dublin_core_mapper.py#L117-L127
+        value = self.source_metadata.get('subject')
+        if not value:
+            return None
+
+        if isinstance(value, str):
+            value = [value]
+        return [{'name': v} for v in value if v]
 
 
 class OaiVernacular(Vernacular):


### PR DESCRIPTION
This is an attempt to implement the chapman_oai_dc mapper in a more explicit way than the previous mappers we've built. We continue to rely on inheritance to build the mapping configuration in `UCLDC_map`, but it's very clear where values are coming from: `source_metadata` or `map_*` functions.

Note also that `collate_fields` has been split into two functions, `collate_values` and `source_metadata_values` in order to separate the fetching of values with the composing of a new list. The use of the word "collate" doesn't quite ring true as an  description of what this function does, but that's as likely my misunderstanding of it than anything else.

This code executes and produces the expected output as far as I am able to determine.

If this approach to mapping is acceptable, we'd go back and make similar changes to `cca_vault` and `islandora`.

If the mapping configuration is too verbose, there are also opportunities to introduce brevity at the expense of some explicitness. For instance, we could reintroduce something like `collate_fields` but one that accepts both `source_metadata` field names and function names and combined them into a list. It'd be nice to have a shorter way to fetch values from `source_metadata` but based on previous discussions, something like `self.get('description')` is off the table.

In any case, we're looking forward to your feedback!